### PR TITLE
Chaotic Alliance Raid compatibility

### DIFF
--- a/PartyIcons/Configuration/DisplaySelectors.cs
+++ b/PartyIcons/Configuration/DisplaySelectors.cs
@@ -10,6 +10,7 @@ public class DisplaySelectors
     public DisplaySelector DisplayDungeon { get; set; } = new(DisplayPreset.BigJobIconAndPartySlot);
     public DisplaySelector DisplayRaid { get; set; } = new(DisplayPreset.RoleLetters);
     public DisplaySelector DisplayAllianceRaid { get; set; } = new(DisplayPreset.BigJobIconAndPartySlot);
+    public DisplaySelector DisplayChaoticRaid { get; set; } = new(DisplayPreset.BigJobIconAndPartySlot);
     public DisplaySelector DisplayFieldOperationParty { get; set; } = new(DisplayPreset.BigJobIconAndPartySlot);
     public DisplaySelector DisplayFieldOperationOthers { get; set; } = new(DisplayPreset.SmallJobIcon);
     public DisplaySelector DisplayOthers { get; set; } = new(DisplayPreset.SmallJobIcon);

--- a/PartyIcons/Configuration/Settings.cs
+++ b/PartyIcons/Configuration/Settings.cs
@@ -45,6 +45,7 @@ public class Settings : IPluginConfiguration
     public StatusConfigs StatusConfigs { get; set; } = new();
     public ChatConfig ChatOverworld { get; set; } = new(ChatMode.Role);
     public ChatConfig ChatAllianceRaid { get; set; } = new(ChatMode.Role);
+    public ChatConfig ChatChaoticRaid { get; set; } = new(ChatMode.Role);
     public ChatConfig ChatDungeon { get; set; } = new(ChatMode.Job);
     public ChatConfig ChatRaid { get; set; } = new(ChatMode.Role);
     public ChatConfig ChatOthers { get; set; } = new(ChatMode.Job);

--- a/PartyIcons/Configuration/StatusConfig.cs
+++ b/PartyIcons/Configuration/StatusConfig.cs
@@ -169,6 +169,7 @@ public record struct StatusSelector
             ZoneType.Dungeon => StatusPreset.Instances,
             ZoneType.Raid => StatusPreset.Instances,
             ZoneType.AllianceRaid => StatusPreset.Instances,
+            ZoneType.ChaoticRaid => StatusPreset.Instances,
             ZoneType.FieldOperation => StatusPreset.FieldOperations,
             _ => throw new ArgumentOutOfRangeException(nameof(zoneType), zoneType, null)
         };

--- a/PartyIcons/Runtime/ViewModeSetter.cs
+++ b/PartyIcons/Runtime/ViewModeSetter.cs
@@ -14,6 +14,7 @@ public enum ZoneType
     Dungeon,
     Raid,
     AllianceRaid,
+    ChaoticRaid,
     FieldOperation,
 }
 
@@ -116,6 +117,7 @@ public sealed class ViewModeSetter
                 2 => ZoneType.Dungeon,
                 3 => ZoneType.Raid,
                 4 => ZoneType.AllianceRaid,
+                37 => ZoneType.ChaoticRaid,
                 127 => ZoneType.FieldOperation,
                 _ => ZoneType.Dungeon
             };
@@ -130,6 +132,7 @@ public sealed class ViewModeSetter
             ZoneType.Dungeon => _configuration.ChatDungeon,
             ZoneType.Raid => _configuration.ChatRaid,
             ZoneType.AllianceRaid => _configuration.ChatAllianceRaid,
+            ZoneType.ChaoticRaid => _configuration.ChatChaoticRaid,
             ZoneType.FieldOperation => _configuration.ChatOverworld,
             _ => _configuration.ChatDungeon
         };

--- a/PartyIcons/UI/Settings/ChatNameTab.cs
+++ b/PartyIcons/UI/Settings/ChatNameTab.cs
@@ -44,6 +44,11 @@ public static class ChatNameTab
                 () => Plugin.Settings.ChatAllianceRaid,
                 (config) => Plugin.Settings.ChatAllianceRaid = config,
                 "Alliance:");
+
+            ChatModeSection("##chat_chaotic",
+                () => Plugin.Settings.ChatChaoticRaid,
+                (config) => Plugin.Settings.ChatChaoticRaid = config,
+                "Chaotic:");
         }
     }
     

--- a/PartyIcons/UI/Settings/NameplateTab.cs
+++ b/PartyIcons/UI/Settings/NameplateTab.cs
@@ -120,6 +120,10 @@ public sealed class NameplateTab
             NameplateModeSection("##np_alliance", () => Plugin.Settings.DisplaySelectors.DisplayAllianceRaid,
                 sel => Plugin.Settings.DisplaySelectors.DisplayAllianceRaid = sel,
                 "Alliance:");
+
+            NameplateModeSection("##np_chaotic", () => Plugin.Settings.DisplaySelectors.DisplayChaoticRaid,
+               sel => Plugin.Settings.DisplaySelectors.DisplayChaoticRaid = sel,
+               "Chaotic:");
         }
 
         ImGuiExt.SectionHeader("Field Operations");

--- a/PartyIcons/UI/Utils/UiNames.cs
+++ b/PartyIcons/UI/Utils/UiNames.cs
@@ -29,6 +29,7 @@ public static class UiNames
             ZoneType.Dungeon => "Dungeon",
             ZoneType.Raid => "Raid",
             ZoneType.AllianceRaid => "Alliance Raid",
+            ZoneType.ChaoticRaid => "Chaotic Raid",
             ZoneType.FieldOperation => "Field Operation",
             _ => $"Unknown ({(int)zoneType}/{zoneType.ToString()})"
         };

--- a/PartyIcons/View/NameplateView.cs
+++ b/PartyIcons/View/NameplateView.cs
@@ -63,6 +63,7 @@ public sealed class NameplateView : IDisposable
             ZoneType.Dungeon => selectors.DisplayDungeon,
             ZoneType.Raid => selectors.DisplayRaid,
             ZoneType.AllianceRaid => selectors.DisplayAllianceRaid,
+            ZoneType.ChaoticRaid => selectors.DisplayChaoticRaid,
             ZoneType.FieldOperation => selectors.DisplayFieldOperationParty,
             _ => throw new ArgumentOutOfRangeException($"Unknown zone type {zoneType}")
         });
@@ -73,6 +74,7 @@ public sealed class NameplateView : IDisposable
             ZoneType.Dungeon => selectors.DisplayOthers,
             ZoneType.Raid => selectors.DisplayOthers,
             ZoneType.AllianceRaid => selectors.DisplayOthers,
+            ZoneType.ChaoticRaid => selectors.DisplayOthers,
             ZoneType.FieldOperation => selectors.DisplayFieldOperationOthers,
             _ => throw new ArgumentOutOfRangeException($"Unknown zone type {zoneType}")
         });


### PR DESCRIPTION
This adds the content type for the new chaotic raid, and sets it as a new option in the plugin UI. I've used it in two raids so far, seems to work perfectly fine with my setup of Role Letters.


![rhr5iFNKcX](https://github.com/user-attachments/assets/5d0554cc-67c5-4806-bac1-3121da43d434)
